### PR TITLE
Added Code Analysis Rulesets and File Headers

### DIFF
--- a/CustomAnalysisRules.Test.ruleset
+++ b/CustomAnalysisRules.Test.ruleset
@@ -1,0 +1,134 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="C# Inn Rules for Test Projects" Description="The code analysis rules used for the C# Inn Website Test Projects." ToolsVersion="14.0">
+  <Include Path="CustomAnalysisRules.ruleset" Action="Default" />
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA1707" Action="None" />
+    <Rule Id="CA1000" Action="None" />
+    <Rule Id="CA1008" Action="None" />
+    <Rule Id="CA1010" Action="None" />
+    <Rule Id="CA1012" Action="None" />
+    <Rule Id="CA1014" Action="None" />
+    <Rule Id="CA1016" Action="None" />
+    <Rule Id="CA1017" Action="None" />
+    <Rule Id="CA1018" Action="None" />
+    <Rule Id="CA1024" Action="None" />
+    <Rule Id="CA1027" Action="None" />
+    <Rule Id="CA1028" Action="None" />
+    <Rule Id="CA1030" Action="None" />
+    <Rule Id="CA1033" Action="None" />
+    <Rule Id="CA1034" Action="None" />
+    <Rule Id="CA1036" Action="None" />
+    <Rule Id="CA1040" Action="None" />
+    <Rule Id="CA1041" Action="None" />
+    <Rule Id="CA1043" Action="None" />
+    <Rule Id="CA1044" Action="None" />
+    <Rule Id="CA1050" Action="None" />
+    <Rule Id="CA1051" Action="None" />
+    <Rule Id="CA1052" Action="None" />
+    <Rule Id="CA1054" Action="None" />
+    <Rule Id="CA1055" Action="None" />
+    <Rule Id="CA1056" Action="None" />
+    <Rule Id="CA1060" Action="None" />
+    <Rule Id="CA1061" Action="None" />
+    <Rule Id="CA1063" Action="None" />
+    <Rule Id="CA1064" Action="None" />
+    <Rule Id="CA1065" Action="None" />
+    <Rule Id="CA1066" Action="None" />
+    <Rule Id="CA1067" Action="None" />
+    <Rule Id="CA1068" Action="None" />
+    <Rule Id="CA1507" Action="None" />
+    <Rule Id="CA1708" Action="None" />
+    <Rule Id="CA1710" Action="None" />
+    <Rule Id="CA1711" Action="None" />
+    <Rule Id="CA1714" Action="None" />
+    <Rule Id="CA1715" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+    <Rule Id="CA1717" Action="None" />
+    <Rule Id="CA1720" Action="None" />
+    <Rule Id="CA1721" Action="None" />
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1725" Action="None" />
+    <Rule Id="CA1801" Action="None" />
+    <Rule Id="CA1802" Action="None" />
+    <Rule Id="CA1806" Action="None" />
+    <Rule Id="CA1812" Action="None" />
+    <Rule Id="CA1814" Action="None" />
+    <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+    <Rule Id="CA1822" Action="None" />
+    <Rule Id="CA1823" Action="None" />
+    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2119" Action="None" />
+    <Rule Id="CA2211" Action="None" />
+    <Rule Id="CA2214" Action="None" />
+    <Rule Id="CA2217" Action="None" />
+    <Rule Id="CA2219" Action="None" />
+    <Rule Id="CA2222" Action="None" />
+    <Rule Id="CA2225" Action="None" />
+    <Rule Id="CA2226" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+    <Rule Id="CA2231" Action="None" />
+    <Rule Id="CA2244" Action="None" />
+    <Rule Id="CA9999" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.CSharp.Analyzers" RuleNamespace="Microsoft.NetCore.CSharp.Analyzers">
+    <Rule Id="CA1309" Action="None" />
+    <Rule Id="CA1414" Action="None" />
+    <Rule Id="CA1601" Action="None" />
+    <Rule Id="CA1810" Action="None" />
+    <Rule Id="CA1824" Action="None" />
+    <Rule Id="CA1825" Action="None" />
+    <Rule Id="CA2010" Action="None" />
+    <Rule Id="CA2201" Action="None" />
+    <Rule Id="CA2205" Action="None" />
+    <Rule Id="CA2207" Action="None" />
+    <Rule Id="CA2215" Action="None" />
+    <Rule Id="CA5350" Action="None" />
+    <Rule Id="CA5351" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1307" Action="None" />
+    <Rule Id="CA1308" Action="None" />
+    <Rule Id="CA1401" Action="None" />
+    <Rule Id="CA1813" Action="None" />
+    <Rule Id="CA1816" Action="None" />
+    <Rule Id="CA1820" Action="None" />
+    <Rule Id="CA1826" Action="None" />
+    <Rule Id="CA2002" Action="None" />
+    <Rule Id="CA2008" Action="None" />
+    <Rule Id="CA2009" Action="None" />
+    <Rule Id="CA2101" Action="None" />
+    <Rule Id="CA2208" Action="None" />
+    <Rule Id="CA2216" Action="None" />
+    <Rule Id="CA2241" Action="None" />
+    <Rule Id="CA2242" Action="None" />
+    <Rule Id="CA2243" Action="None" />
+    <Rule Id="CA9999" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.CSharp.Analyzers" RuleNamespace="Microsoft.CodeQuality.CSharp.Analyzers">
+    <Rule Id="Async001" Action="None" />
+    <Rule Id="Async002" Action="None" />
+    <Rule Id="Async003" Action="None" />
+    <Rule Id="Async004" Action="None" />
+    <Rule Id="Async005" Action="None" />
+    <Rule Id="Async006" Action="None" />
+    <Rule Id="CA1001" Action="None" />
+    <Rule Id="CA1003" Action="None" />
+    <Rule Id="CA1019" Action="None" />
+    <Rule Id="CA1032" Action="None" />
+    <Rule Id="CA1200" Action="None" />
+    <Rule Id="CA1500" Action="None" />
+    <Rule Id="CA1726" Action="None" />
+    <Rule Id="CA1821" Action="None" />
+    <Rule Id="CA2000" Action="None" />
+    <Rule Id="CA2001" Action="None" />
+    <Rule Id="CA2109" Action="None" />
+    <Rule Id="CA2200" Action="None" />
+    <Rule Id="CA2234" Action="None" />
+  </Rules>
+</RuleSet>

--- a/CustomAnalysisRules.ruleset
+++ b/CustomAnalysisRules.ruleset
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="C# Inn Analysis Rules" Description="The code analysis rules used for the C# Inn Website Projects" ToolsVersion="14.0">
+  <Include Path="minimumrecommendedrules.ruleset" Action="Default" />
+  <Include Path="securityrules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0003" Action="Warning" />
+    <Rule Id="IDE0004" Action="Warning" />
+    <Rule Id="IDE0005" Action="Warning" />
+    <Rule Id="IDE1005" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="CS1591" Action="None" />
+    <Rule Id="SA0001" Action="None" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1308" Action="None" />
+    <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1512" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1629" Action="None" />
+    <Rule Id="SA1652" Action="None" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.Analyzers" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="CA2007" Action="Info" />
+    <Rule Id="CA1716" Action="Info" />
+    <Rule Id="CA1054" Action="Info" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeQuality.CSharp.Analyzers" RuleNamespace="Microsoft.CodeQuality.CSharp.Analyzers">
+    <Rule Id="CA1032" Action="Info" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
+    <Rule Id="CA1305" Action="Info" />
+  </Rules>
+</RuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,44 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <DebugType>Full</DebugType>
+    <LangVersion>7.3</LangVersion>
+    <HighEntropyVA>true</HighEntropyVA>
+    <EnableSourceLink Condition="$([MSBuild]::IsOSPlatform('osx'))">false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
+    <!--This will target the latest patch release of the runtime released with the current SDK.  -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(EnableSourceLink)' == 'true' ">
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="$(MSBuildProjectName.Contains('Test'))">
+      <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\CustomAnalysisRules.Test.ruleset</CodeAnalysisRuleSet>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <IsPackable>true</IsPackable>
+        <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\CustomAnalysisRules.ruleset</CodeAnalysisRuleSet>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19270-01" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
+
+</Project>

--- a/src/CSInn.Domain.Repositories/ILessonsRepository.cs
+++ b/src/CSInn.Domain.Repositories/ILessonsRepository.cs
@@ -1,6 +1,11 @@
-﻿using CSInn.Domain.Models.Content;
+﻿// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
 using System;
 using System.Collections.Generic;
+using CSInn.Domain.Models.Content;
 
 namespace CSInn.Domain.Repositories
 {
@@ -8,8 +13,11 @@ namespace CSInn.Domain.Repositories
     {
         // TODO: Specification pattern so we can mix criterias.
         IEnumerable<Lesson> GetByTags(params string[] tags);
+
         IEnumerable<Lesson> GetByName(string name);
+
         IEnumerable<Lesson> GetByAuthors(params string[] authors);
+
         IEnumerable<Lesson> GetByDate(DateTime from, DateTime to);
     }
 }

--- a/src/CSInn.Domain.Repositories/IRepository.cs
+++ b/src/CSInn.Domain.Repositories/IRepository.cs
@@ -1,15 +1,23 @@
-﻿using System;
+﻿// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
 using System.Collections.Generic;
-using System.Text;
 
 namespace CSInn.Domain.Repositories
 {
-    public interface IRepository<TModel> where TModel : class
+    public interface IRepository<TModel>
+        where TModel : class
     {
         void Create(TModel model);
+
         void Update(TModel model);
+
         void Delete(int key);
+
         IEnumerable<TModel> Get();
+
         TModel Get(int id);
     }
 }

--- a/src/CSInn.Models/Exceptions/InvalidLessonException.cs
+++ b/src/CSInn.Models/Exceptions/InvalidLessonException.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace CSInn.Domain.Models.Content.Exceptions
 {
     public class InvalidLessonException : Exception
     {
-        public InvalidLessonException(bool isTitleEmpty, bool isDescriptionEmpty, bool areNoTags, bool areNoAuthors): 
-            base(BuildErrorMessage(isTitleEmpty, isDescriptionEmpty, areNoTags, areNoAuthors))
+        public InvalidLessonException(bool isTitleEmpty, bool isDescriptionEmpty, bool areNoTags, bool areNoAuthors)
+            : base(BuildErrorMessage(isTitleEmpty, isDescriptionEmpty, areNoTags, areNoAuthors))
         {
-
         }
 
         private static string BuildErrorMessage(bool isTitleEmpty, bool isDescriptionEmpty, bool areNoTags, bool areNoAuthors)

--- a/src/CSInn.Models/Lesson.cs
+++ b/src/CSInn.Models/Lesson.cs
@@ -1,30 +1,24 @@
-﻿/*
- * should we allow users to upload attachments that they may think help users in theirendeavor for learning? 
- * 
+﻿// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+/*
+ * should we allow users to upload attachments that they may think help users in theirendeavor for learning?
+ *
  * Example: User uploads a database for another user to use, or uploads code snippets/examples for users
  *          to play with or understand the code?
- *          
- */ 
+ *
+ */
 
-
-
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using CSInn.Domain.Models.Content.Exceptions;
 
 namespace CSInn.Domain.Models.Content
 {
     public class Lesson
     {
-        public string Title { get; }
-        public string Description { get; set; }
-        public string Video { get; set; }
-        public string Slides { get; set; }
-        public IList<string> Tags { get; set; }
-        public IList<string> Authors { get; }
-
         public Lesson(string title, string description, IEnumerable<string> tags, IEnumerable<string> authors)
         {
             Title = title;
@@ -41,8 +35,18 @@ namespace CSInn.Domain.Models.Content
             {
                 throw new InvalidLessonException(isTitleEmpty, isDescriptionEmpty, areNoTags, areNoAuthors);
             }
-
         }
-    }
 
+        public string Title { get; }
+
+        public string Description { get; set; }
+
+        public string Video { get; set; }
+
+        public string Slides { get; set; }
+
+        public IList<string> Tags { get; set; }
+
+        public IList<string> Authors { get; }
+    }
 }

--- a/src/CSInn.UI/Data/WeatherForecast.cs
+++ b/src/CSInn.UI/Data/WeatherForecast.cs
@@ -1,3 +1,8 @@
+// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
 using System;
 
 namespace CSInn.Data

--- a/src/CSInn.UI/Data/WeatherForecastService.cs
+++ b/src/CSInn.UI/Data/WeatherForecastService.cs
@@ -1,3 +1,8 @@
+// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,7 +13,7 @@ namespace CSInn.Data
     {
         private static readonly string[] Summaries = new[]
         {
-            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+            "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
         };
 
         public Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
@@ -18,7 +23,7 @@ namespace CSInn.Data
             {
                 Date = startDate.AddDays(index),
                 TemperatureC = rng.Next(-20, 55),
-                Summary = Summaries[rng.Next(Summaries.Length)]
+                Summary = Summaries[rng.Next(Summaries.Length)],
             }).ToArray());
         }
     }

--- a/src/CSInn.UI/Program.cs
+++ b/src/CSInn.UI/Program.cs
@@ -1,13 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore;
+// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace CSInn
 {

--- a/src/CSInn.UI/Startup.cs
+++ b/src/CSInn.UI/Startup.cs
@@ -1,15 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+// -------------------------------------------------------------------------------------------------
+// C# Inn Website - © Copyright 2020 - C# Inn
+// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
+// -------------------------------------------------------------------------------------------------
+
+using CSInn.Data;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using CSInn.Data;
 
 namespace CSInn
 {
@@ -41,6 +40,7 @@ namespace CSInn
             else
             {
                 app.UseExceptionHandler("/Error");
+
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }

--- a/stylecop.json
+++ b/stylecop.json
@@ -1,0 +1,27 @@
+﻿{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "C# Inn",
+      "copyrightText": "-------------------------------------------------------------------------------------------------\nC# Inn Website - © Copyright 2020 - {companyName}\nLicensed under the {licenseName} License ({licenseName}). See {licenseFile} in the repo root for license information.\n-------------------------------------------------------------------------------------------------",
+      "variables": {
+        "licenseName": "MIT",
+        "licenseFile": "LICENSE"
+      },
+      "xmlHeader": false,
+      "headerDecoration": "-------------------------------------------------------------------------------------------------"
+    },
+    "orderingRules": {
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "outsideNamespace",
+      "elementOrder": [
+        "kind"
+      ]
+    },
+    "indentation": {
+      "useTabs": false,
+      "indentationSize": 4,
+      "tabSize": 4
+    }
+  }
+}


### PR DESCRIPTION
Includes code quality improvments:
- Code analysis rulesets files list acceptable an unacceptable coding styles. When you perform a build in Visual Studio, build errors are returned when these rules are broken. I have added ruleset files used by Microsoft. To give an example, these rulsets expect `using` statements to be ordered alphabetically and builds fail if they are not. When you don't follow the rules you get the usual red underlines in Visual Studio and can use `Ctrl + .` to get VS to fix them automatically.
- I've added file headers to all cs files. This is also required as part of the rulsets. The header is set in `stylecop.json`. The file header looks like:
```
// -------------------------------------------------------------------------------------------------
// C# Inn Website - © Copyright 2020 - C# Inn
// Licensed under the MIT License (MIT). See LICENSE in the repo root for license information.
// -------------------------------------------------------------------------------------------------
```